### PR TITLE
Move "@glennsl/bs-jest", "bs-jest-date-mock" to dev dependencies

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -16,7 +16,8 @@
     "in-source": true
   },
   "suffix": ".bs.js",
-  "bs-dependencies": ["@glennsl/bs-jest", "bs-moment", "bs-jest-date-mock"],
+  "bs-dependencies": ["bs-moment"],
+  "bs-dev-dependencies": ["@glennsl/bs-jest", "bs-jest-date-mock"],
   "warnings": {
     "error": "+101"
   },


### PR DESCRIPTION
I was getting these 2 errors when I tried to use this package:
```
File "bsconfig.json", line 1
Error: package @glennsl/bs-jest not found or built
- Did you install it?
- If you did, did you run `bsb -make-world`?
```
and
```
File "bsconfig.json", line 1
Error: package bs-jest-date-mock not found or built
- Did you install it?
- If you did, did you run `bsb -make-world`?
```

Fix is self explanatory I think :)